### PR TITLE
ml - search response json includes count (total result count), page (current page number), and results (original search list of results)

### DIFF
--- a/search/views.py
+++ b/search/views.py
@@ -72,13 +72,15 @@ class AccountsSearchView(generics.ListAPIView):
         # query on all models
         else:
             studentSearchResults = Student.objects.none()
+            parentSearchResults = Parent.objects.none()
             instructorSearchResults = Instructor.objects.none()
             adminSearchResults = Admin.objects.none()
             for query in queries.split():
                 studentSearchResults = Student.objects.search(query, studentSearchResults)
+                parentSearchResults = Parent.objects.search(query, parentSearchResults)
                 instructorSearchResults = Instructor.objects.search(query, instructorSearchResults)
                 adminSearchResults = Admin.objects.search(query, adminSearchResults)
-            searchResults = chain(studentSearchResults, instructorSearchResults, adminSearchResults)
+            searchResults = chain(studentSearchResults, parentSearchResults, instructorSearchResults, adminSearchResults)
 
         # sort results
         sortFilter = self.request.query_params.get('sort', None)

--- a/search/views.py
+++ b/search/views.py
@@ -24,6 +24,15 @@ from search.serializers import SearchViewSerializer
 class AccountsSearchView(generics.ListAPIView): 
     serializer_class = SearchViewSerializer
 
+    def list(self, request, *args, **kwargs):
+        response = super().list(request, *args, **kwargs)
+
+        responseDict = {}
+        responseDict["count"] = request.session["count"]
+        responseDict["page"] = request.session["page"]
+        responseDict["results"] = response.data
+        return Response(responseDict)
+
     def get_queryset(self):
         searchResults = Student.objects.none()
 
@@ -88,8 +97,11 @@ class AccountsSearchView(generics.ListAPIView):
                 searchResults = sorted(searchResults, key=lambda obj:obj.updated_at, reverse=True)
 
         searchResults = list(searchResults)
+        self.request.session["count"] = len(searchResults)
+
         # extract searches in page range. Out of bounds page returns nothing
         pageFilter = self.request.query_params.get('page', None)
+        self.request.session["page"] = pageFilter
         if pageFilter is not None:
             try:
                 pageNumber = int(pageFilter)
@@ -108,6 +120,15 @@ class AccountsSearchView(generics.ListAPIView):
 
 class CoursesSearchView(generics.ListAPIView):
     serializer_class = SearchViewSerializer
+
+    def list(self, request, *args, **kwargs):
+        response = super().list(request, *args, **kwargs)
+
+        responseDict = {}
+        responseDict["count"] = request.session["count"]
+        responseDict["page"] = request.session["page"]
+        responseDict["results"] = response.data
+        return Response(responseDict)
 
     def get_queryset(self):
         searchResults = Course.objects.none()
@@ -179,8 +200,11 @@ class CoursesSearchView(generics.ListAPIView):
                 searchResults = searchResults.order_by(sortToParameter[sortFilter])
 
         searchResults = list(searchResults)
+        self.request.session["count"] = len(searchResults)
+
         # extract searches in page range
         pageFilter = self.request.query_params.get('page', None)
+        self.request.session["page"] = pageFilter
         if pageFilter is not None:
             try:
                 pageNumber = int(pageFilter)


### PR DESCRIPTION
3 new JSON parameters:
count (total result count)
page (current page number. Set to null if no page filter specified)
results (original search list of results)

New return JSON body:
{
    "count": 2,
    "page": "1",
    "results": [
        {
        ... same list of accounts/courses as before
        }
}