### PR TITLE
ml - session title set to course subject upon creation

### DIFF
--- a/course/serializers.py
+++ b/course/serializers.py
@@ -101,7 +101,8 @@ class CourseSerializer(serializers.ModelSerializer):
                     start_datetime=start_datetime,
                     end_datetime=end_datetime,
                     instructor=course.instructor,
-                    is_confirmed= course.is_confirmed and current_date <= confirmed_end_date
+                    is_confirmed= course.is_confirmed and current_date <= confirmed_end_date,
+                    title=course.subject
                 )
                 course.num_sessions += 1
                 current_date = current_date.shift(weeks=+1)

--- a/scheduler/serializers.py
+++ b/scheduler/serializers.py
@@ -1,4 +1,5 @@
 from scheduler.models import Session
+from course.models import Course
 from rest_framework import serializers
 
 


### PR DESCRIPTION
issue #53 

Session titles are set to course subject upon creation as part of course creation.