### PR TITLE
Fix Create Invoice

### DIFF
--- a/course/models.py
+++ b/course/models.py
@@ -226,9 +226,9 @@ class Enrollment(models.Model):
 
     @property
     def enrollment_status(self):
-        invoices = self.registration_set.values_list('invoice', flat=True)
+        invoices = self.registration_set.values_list("invoice", flat=True)
         if invoices:
-            return invoices.order_by('-created_at')[0].payment_status
+            return invoices.order_by("-created_at")[0].payment_status
 
     # Timestamps
     updated_at = models.DateTimeField(auto_now=True)

--- a/invoice/migrations/0011_invoice_payment_due_date.py
+++ b/invoice/migrations/0011_invoice_payment_due_date.py
@@ -6,13 +6,13 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('invoice', '0010_auto_20210221_0420'),
+        ("invoice", "0010_auto_20210221_0420"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='invoice',
-            name='payment_due_date',
+            model_name="invoice",
+            name="payment_due_date",
             field=models.DateField(blank=True, null=True),
         ),
     ]

--- a/invoice/mutations.py
+++ b/invoice/mutations.py
@@ -44,22 +44,22 @@ class CreateInvoice(graphene.Mutation):
     def mutate(root, info, **validated_data):
         data = validated_data
 
-        if data.get('pay_now', False) and data['method'] != 'credit_card':
+        if data.get("pay_now", False) and data["method"] != "credit_card":
             # only admins may create a cash/check invoice to be paid now
             if not Admin.objects.filter(user__id=info.context.user.id).exists():
-                raise GraphQLError("Failed Mutation. Only Admins may create cash/check invoices to be paid now.")
+                raise GraphQLError(
+                    "Failed Mutation. Only Admins may create cash/check invoices to be paid now."
+                )
 
         # update invoice
-        if data.get('invoice_id'):
+        if data.get("invoice_id"):
             # only admins may update an invoice
             if not Admin.objects.filter(user__id=info.context.user.id).exists():
                 raise GraphQLError("Failed Mutation. Only Admins may update Invoices.")
 
             # can only update method or payment_status
             updatedData = {
-                key: data[key]
-                for key in ("method", "payment_status")
-                if key in data
+                key: data[key] for key in ("method", "payment_status") if key in data
             }
 
             # update
@@ -126,7 +126,9 @@ class CreateInvoice(graphene.Mutation):
                 stripe_account="acct_1HqSAYETk4EmXsx3",
             )
             stripe_checkout_id = session.id
-        elif data.get("pay_now", False) and (data["method"] == "cash" or data["method"] == "check"):
+        elif data.get("pay_now", False) and (
+            data["method"] == "cash" or data["method"] == "check"
+        ):
             invoice.payment_status = "paid"
             invoice.payment_method = data["method"]
             invoice.save()

--- a/invoice/mutations.py
+++ b/invoice/mutations.py
@@ -56,15 +56,15 @@ class CreateInvoice(graphene.Mutation):
                 raise GraphQLError("Failed Mutation. Only Admins may update Invoices.")
 
             # can only update method or payment_status
-            data = {
+            updatedData = {
                 key: data[key]
-                for key in ("method", "payment_status", "invoice_id")
+                for key in ("method", "payment_status")
                 if key in data
             }
 
             # update
             invoice = Invoice.objects.get(id=data.pop("invoice_id"))
-            Invoice.objects.filter(id=invoice.id).update(**data)
+            Invoice.objects.filter(id=invoice.id).update(**updatedData)
             invoice.refresh_from_db()
 
             operation = CHANGE
@@ -126,6 +126,10 @@ class CreateInvoice(graphene.Mutation):
                 stripe_account="acct_1HqSAYETk4EmXsx3",
             )
             stripe_checkout_id = session.id
+        elif data.get("pay_now", False) and (data["method"] == "cash" or data["method"] == "check"):
+            invoice.payment_status = "paid"
+            invoice.payment_method = data["method"]
+            invoice.save()
         else:
             # unpaid flow
             invoice.payment_due_date = arrow.utcnow().shift(days=5)

--- a/onboarding/migrations/0003_business_stripe_account_id.py
+++ b/onboarding/migrations/0003_business_stripe_account_id.py
@@ -6,13 +6,13 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('onboarding', '0002_auto_20210502_0028'),
+        ("onboarding", "0002_auto_20210502_0028"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='business',
-            name='stripe_account_id',
+            model_name="business",
+            name="stripe_account_id",
             field=models.CharField(blank=True, max_length=50, null=True),
         ),
     ]

--- a/onboarding/mutations.py
+++ b/onboarding/mutations.py
@@ -985,16 +985,16 @@ class StripeOnboarding(graphene.Mutation):
         admin = Admin.objects.get(user__id=user_id)
         stripe.api_key = settings.STRIPE_API_KEY
 
-        account = stripe.Account.create(type='standard', email=admin.user.email)
+        account = stripe.Account.create(type="standard", email=admin.user.email)
         business = admin.business
         business.stripe_account_id = account.stripe_id
         business.save()
 
         account_links = stripe.AccountLink.create(
             account=account.id,
-            refresh_url=f'{settings.BASE_URL}/{refresh_url_param}',
-            return_url=f'{settings.BASE_URL}/{return_url_param}',
-            type='account_onboarding'
+            refresh_url=f"{settings.BASE_URL}/{refresh_url_param}",
+            return_url=f"{settings.BASE_URL}/{return_url_param}",
+            type="account_onboarding",
         )
 
         return StripeOnboarding(onboarding_url=account_links.url)


### PR DESCRIPTION
# Goal
Fix error in updating invoice and add functionality for pay now with cash and check

## Details
Line 59 was meant to filter out any mutation parameters that were not "method" or "payment_status" before updating the invoice. This however changed the data dictionary which is used later in the function causing problems. Bug fixed by creating a new dictionary updatedData to handle the filtering of what can be updated as part of an invoice.

Added a conditional to check if request is to pay now with cash or check. In there the payment status is set as "paid" and the payment method is set to what was passed in.