### PR TITLE
Tutor scheduling

### DIFF
--- a/account/mutations.py
+++ b/account/mutations.py
@@ -255,6 +255,7 @@ class CreateParent(graphene.Mutation):
         state = graphene.String()
         zipcode = graphene.String()
 
+        business_id = graphene.ID(name="business")
         # Parent fields
         relationship = RelationshipEnum()
         secondary_phone_number = graphene.String()

--- a/course/models.py
+++ b/course/models.py
@@ -226,9 +226,9 @@ class Enrollment(models.Model):
 
     @property
     def enrollment_status(self):
-        invoices = self.registration_set.values_list('invoice', flat=True)
+        invoices = self.registration_set.values_list("invoice", flat=True)
         if invoices:
-            return invoices.order_by('-created_at')[0].payment_status
+            return invoices.order_by("-created_at")[0].payment_status
 
     # Timestamps
     updated_at = models.DateTimeField(auto_now=True)

--- a/invoice/migrations/0011_invoice_payment_due_date.py
+++ b/invoice/migrations/0011_invoice_payment_due_date.py
@@ -6,13 +6,13 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('invoice', '0010_auto_20210221_0420'),
+        ("invoice", "0010_auto_20210221_0420"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='invoice',
-            name='payment_due_date',
+            model_name="invoice",
+            name="payment_due_date",
             field=models.DateField(blank=True, null=True),
         ),
     ]

--- a/invoice/mutations.py
+++ b/invoice/mutations.py
@@ -44,13 +44,15 @@ class CreateInvoice(graphene.Mutation):
     def mutate(root, info, **validated_data):
         data = validated_data
 
-        if data.get('pay_now', False) and data['method'] != 'credit_card':
+        if data.get("pay_now", False) and data["method"] != "credit_card":
             # only admins may create a cash/check invoice to be paid now
             if not Admin.objects.filter(user__id=info.context.user.id).exists():
-                raise GraphQLError("Failed Mutation. Only Admins may create cash/check invoices to be paid now.")
+                raise GraphQLError(
+                    "Failed Mutation. Only Admins may create cash/check invoices to be paid now."
+                )
 
         # update invoice
-        if data.get('invoice_id'):
+        if data.get("invoice_id"):
             # only admins may update an invoice
             if not Admin.objects.filter(user__id=info.context.user.id).exists():
                 raise GraphQLError("Failed Mutation. Only Admins may update Invoices.")

--- a/onboarding/migrations/0003_business_stripe_account_id.py
+++ b/onboarding/migrations/0003_business_stripe_account_id.py
@@ -6,13 +6,13 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('onboarding', '0002_auto_20210502_0028'),
+        ("onboarding", "0002_auto_20210502_0028"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='business',
-            name='stripe_account_id',
+            model_name="business",
+            name="stripe_account_id",
             field=models.CharField(blank=True, max_length=50, null=True),
         ),
     ]

--- a/onboarding/mutations.py
+++ b/onboarding/mutations.py
@@ -985,16 +985,16 @@ class StripeOnboarding(graphene.Mutation):
         admin = Admin.objects.get(user__id=user_id)
         stripe.api_key = settings.STRIPE_API_KEY
 
-        account = stripe.Account.create(type='standard', email=admin.user.email)
+        account = stripe.Account.create(type="standard", email=admin.user.email)
         business = admin.business
         business.stripe_account_id = account.stripe_id
         business.save()
 
         account_links = stripe.AccountLink.create(
             account=account.id,
-            refresh_url=f'{settings.BASE_URL}/{refresh_url_param}',
-            return_url=f'{settings.BASE_URL}/{return_url_param}',
-            type='account_onboarding'
+            refresh_url=f"{settings.BASE_URL}/{refresh_url_param}",
+            return_url=f"{settings.BASE_URL}/{return_url_param}",
+            type="account_onboarding",
         )
 
         return StripeOnboarding(onboarding_url=account_links.url)

--- a/scheduler/schema.py
+++ b/scheduler/schema.py
@@ -354,7 +354,7 @@ class Query(object):
         user = Parent.objects.get(user=info.context.user)
         business_id = user.business.id
         queryset = Instructor.objects.all()
-        
+
         if topic is not None:
             queryset = queryset.filter(subjects=topic)
 
@@ -374,10 +374,9 @@ class Query(object):
                         business_id,
                         new_start_date,
                         new_end_date,
-                        duration
+                        duration,
                     ),
                 }
             )
 
         return tutoring_availabilities
-

--- a/scheduler/utilities.py
+++ b/scheduler/utilities.py
@@ -1,0 +1,53 @@
+from datetime import datetime, time, timedelta, date
+from typing import final
+from account.models import (
+    Instructor,
+    InstructorAvailability,
+    InstructorOutOfOffice,
+)
+from onboarding.models import Business
+
+
+def time_to_index(time: datetime, day_of_week: str, business_id: int) -> int:
+    # index = time - start_time/ 30 min
+    business = Business.objects.get(id=business_id)
+    start_time = business.availability_list.get(day_of_week=day_of_week).start_time
+    today = datetime.today()
+    selected_time = datetime.combine(today, time)
+    business_start_time = datetime.combine(today, start_time)
+    difference = selected_time - business_start_time
+    minutes = difference.total_seconds() / 60
+    index = minutes / 30
+    return int(index)
+
+
+def index_to_time(index: int, day_of_week: str, business_id: int) -> datetime:
+    business = Business.objects.get(id=business_id)
+    start_time = business.availability_list.get(day_of_week=day_of_week).start_time
+    today = datetime.today()
+    business_start_time = (datetime.combine(today, start_time)).time()
+    minutes = business_start_time.hour * 60 + business_start_time.minute
+
+    total_minutes = minutes + (30 * index)
+    final_time = timedelta(minutes=total_minutes)
+    return final_time
+
+
+def get_buessiness_hours_map(buesiness_id: int) -> dict:
+    # create a function that returns a dict of days as keys and array of bools for the amount of hours in a day
+    business = Business.objects.get(id=buesiness_id)
+    avail = business.availability_list
+    r = avail
+    print(r)
+
+
+def set_instructor_availabilities(
+    instructor_id: int, instructor_availiablities_map: dict
+) -> dict:
+    pass
+
+
+print(get_buessiness_hours_map(buesiness_id=1))
+# day = time(10, 30)
+# print(index_to_time(9, "monday", 1))
+# print(time_to_index(day, "monday", 1))

--- a/scheduler/utilities.py
+++ b/scheduler/utilities.py
@@ -1,4 +1,4 @@
-from datetime import datetime, time, timedelta, date
+from datetime import datetime, time, timedelta, 
 from account.models import (
     Instructor,
     InstructorAvailability,
@@ -6,12 +6,11 @@ from account.models import (
 )
 from onboarding.models import Business
 from scheduler.models import Session
-from django.utils import timezone
-from course.models import Course
-
-print("something")
 
 
+
+# Converts a python datetime.time() object to an index depending on the business
+# hours start time
 def time_to_index(time: datetime, day_of_week: str, business_id: int) -> int:
     # index = time - start_time/ 30 min
     business = Business.objects.get(id=business_id)
@@ -25,6 +24,7 @@ def time_to_index(time: datetime, day_of_week: str, business_id: int) -> int:
     return int(index)
 
 
+# Converts an index to python timedelta given day of week and business id
 def index_to_time(index: int, day_of_week: str, business_id: int) -> datetime:
     business = Business.objects.get(id=business_id)
     start_time = business.availability_list.get(day_of_week=day_of_week).start_time
@@ -32,10 +32,12 @@ def index_to_time(index: int, day_of_week: str, business_id: int) -> datetime:
     business_start_time = (datetime.combine(today, start_time)).time()
     minutes = business_start_time.hour * 60 + business_start_time.minute
     total_minutes = minutes + (30 * index)
-    final_time = timedelta(minutes=total_minutes)
+    time_delta = timedelta(minutes=total_minutes)
+    final_time = (datetime.min + time_delta).time()
     return final_time
 
 
+# Returns a list of False given a start and end time
 def duration_to_boolean_list(start_time, end_time):
     today = datetime.today()
     start_time = datetime.combine(today, start_time)
@@ -43,10 +45,12 @@ def duration_to_boolean_list(start_time, end_time):
     difference = end_time - start_time
     total_minutes = difference.total_seconds() / 60
     index = total_minutes / 30
-    return [True] * int(index)
+    return [False] * int(index)
 
 
-def get_buessiness_hours_map(buesiness_id: int) -> dict:
+# Given business id, return a dict of day of week as keys and response of
+# duration bool list as the value
+def get_business_hours_map(buesiness_id: int) -> dict:
     availability_dict = {}
     business = Business.objects.get(id=buesiness_id)
     avail = business.availability_list.all()
@@ -60,7 +64,83 @@ def get_buessiness_hours_map(buesiness_id: int) -> dict:
     return availability_dict
 
 
-def get_instructor_sessions(instructor_id: int, start_date, end_date) -> list:
+# Gets start and end time of instructors availabilities and sets the values to
+# true comparing the business hours
+def get_instructor_availabilities(instructor_id: int, business_id: int) -> dict:
+    # compares business hours and sets the instructors availability
+    instructor_availablilities_map = get_business_hours_map(buesiness_id=business_id)
+    # gets instructors availablities
+    instructor_availability_dict = InstructorAvailability.objects.filter(
+        instructor=instructor_id
+    )
+
+    for instructors_availability in instructor_availability_dict:
+        day_of_week = instructors_availability.day_of_week
+        start_index = time_to_index(
+            instructors_availability.start_time,
+            instructors_availability.day_of_week,
+            business_id,
+        )
+        end_index = time_to_index(
+            instructors_availability.end_time,
+            instructors_availability.day_of_week,
+            business_id,
+        )
+        for index in range(start_index, end_index):
+            instructor_availablilities_map[day_of_week][index] = True
+
+    return instructor_availablilities_map
+
+
+# create an object of keys as the day of week and array of unique start times
+def find_instructor_teaching_schedule(
+    day_of_week, instructor_sessions, business_id, weekdays
+):
+
+    # filter all sessions by day of week
+    sessions_for_day_of_week = [
+        session
+        for session in instructor_sessions
+        if session.start_datetime.weekday() == day_of_week
+    ]
+
+    # return an array of start times
+    unique_unavailable_start_times_for_day_of_week = []
+    seen = []
+    for session in sessions_for_day_of_week:
+        if session.availability.start_time not in seen:
+            unique_unavailable_start_times_for_day_of_week.append(
+                (
+                    time_to_index(
+                        session.availability.start_time,
+                        weekdays[day_of_week],
+                        business_id,
+                    ),
+                    time_to_index(
+                        session.availability.end_time,
+                        weekdays[day_of_week],
+                        business_id,
+                    ),
+                )
+            )
+            seen.append(session.availability.start_time)
+
+    # sorts list of tuples
+    if len(unique_unavailable_start_times_for_day_of_week) > 0:
+        unique_unavailable_start_times_for_day_of_week.sort(key=lambda tup: tup[0])
+        return unique_unavailable_start_times_for_day_of_week
+    else:
+        return []
+
+
+# Returns a dict of days of week as keys and instructors availability
+def get_instructor_tutoring_availablity(
+    instructor_id: int,
+    business_id: int,
+    start_date: datetime,
+    end_date: datetime,
+    duration: float,
+) -> list:
     weekdays = {
         0: "monday",
         1: "tuesday",
@@ -70,41 +150,133 @@ def get_instructor_sessions(instructor_id: int, start_date, end_date) -> list:
         5: "saturday",
         6: "sunday",
     }
-    instructor_availabilities_dict = {}
+    # gets instructors availabilities compared to the business hours
+    instructor_availabilities_dict = get_instructor_availabilities(
+        instructor_id, business_id
+    )
+
+    # gets all single instructors sessions between start_date and end_date.
     instructor_sessions = Session.objects.filter(
         start_datetime__range=(start_date, end_date),
         end_datetime__range=(start_date, end_date),
         instructor_id=instructor_id,
     )
 
-    # Need to get start & end time of course
-    instructor_availability = InstructorAvailability.objects.filter(instructor=2)
-
-    print(instructor_availability)
-
-    for e in instructor_sessions:
-        if weekdays[e.start_datetime.weekday()] not in instructor_availabilities_dict:
-            instructor_availabilities_dict[weekdays[e.start_datetime.weekday()]] = 1
-
-
-def set_instructor_business_availabilities(instructor_id: int) -> dict:
-    pass
+    # gets unique start times for each session and stores it in obj
+    instructor_teaching_schedule_dict = {}
+    for day in range(7):
+        if weekdays[day] not in instructor_teaching_schedule_dict:
+            instructor_teaching_schedule_dict[
+                weekdays[day]
+            ] = find_instructor_teaching_schedule(
+                day, instructor_sessions, business_id, weekdays
+            )
 
 
-def get_instructor_availabilities(instructor_id: int, start_date, end_date) -> dict:
-    # given an instructor ID and a start & end time
-    # return an object with possible availabilities
-    # get business hours map
-    #
-    pass
+    def find_all_start_time_indices(
+            inst_avail_list,
+        ):
+            counter = 0
+            consecutive_index = []
+            pos = -1
+            for idx, val in enumerate(inst_avail_list):
+                if val == True and pos == -1:
+                    counter += 1
+                    pos = idx
+                elif val == True:
+                    counter += 1
+                elif pos != -1:
+                    consecutive_index.append(pos)
+                    pos = -1
+                    counter = 0
+            if counter > 0:
+                consecutive_index.append(pos)
+
+            return consecutive_index
+    # helper function to set instructor hours
+    def set_instructor_availability_map(
+        instructor_teaching_schedule, inst_avail_dict, duration
+    ):
+        duration_map = {
+            0.5: 1,
+            1.0: 2,
+            1.5: 3,
+            2.0: 4,
+        }
+
+        # loop through business_hours array
+        for day in instructor_teaching_schedule:
+            for teaching_range in sorted(
+                instructor_teaching_schedule[day], key=lambda tup: tup[0]
+            ):
+                teaching_range_start_index = teaching_range[0]
+                teaching_range_end_index = teaching_range[1]
+                for time_index in range(
+                    teaching_range_start_index, teaching_range_end_index
+                ):
+                    inst_avail_dict[day][time_index] = False
+
+        
+        for day in inst_avail_dict:
+            
+            # Find all available start time indices
+            requested_start_index_list = find_all_start_time_indices(inst_avail_dict[day])
+            # For each start time indices
+            
+            for requested_start_time_index in requested_start_index_list:
+                 
+                shortest_index_distance = None
+                closest_teaching_range = None    
+                # Find requested end time index
+                requested_end_time_index = requested_start_time_index + duration_map[duration]
+                # loops through tuple of instructor session start time & end time indices 
+                for instructor_teaching_hours_range in instructor_teaching_schedule_dict[day]:
+                    # finds the shortest distances by subtracting the requested end time index with the start time of session
+
+                    current_index_distance = abs(requested_end_time_index - instructor_teaching_hours_range[0])
+
+                    if shortest_index_distance is None or closest_teaching_range is None:
+                        closest_teaching_range = instructor_teaching_hours_range
+                        shortest_index_distance = current_index_distance
+
+                    if current_index_distance < shortest_index_distance and shortest_index_distance is not None and closest_teaching_range is not None:
+                        closest_teaching_range = instructor_teaching_hours_range
+                        shortest_index_distance = current_index_distance
+                        
+                      
+                # helper function to set the instructors availability dict output     
+                def set_instructor_availability_dict(start_time_index,end_time_index):
+                    for time_index in range(start_time_index, end_time_index):
+                        inst_avail_dict[day][time_index] = False
 
 
-st = time(10, 0)
-et = time(11, 00)
-sd = datetime(2020, 1, 26, 10, 0, tzinfo=timezone.utc)
-ed = datetime(2021, 10, 15, 11, 0, tzinfo=timezone.utc)
-# print(get_instructor_availabilities(2, sd, ed))
-# print(get_instructor_sessions(5, sd, ed))
-print(get_buessiness_hours_map(buesiness_id=1))
-# print(index_to_time(1, "monday", 1))
-# print(time_to_index(selected_time, "monday", 1))
+                if closest_teaching_range is not None:
+                    
+                    # checks if the next 30 min session goes over the duration 
+                    if abs(requested_start_time_index + 1 - closest_teaching_range[0]) < duration_map[duration]:
+                        set_instructor_availability_dict(requested_start_time_index + 1, closest_teaching_range[0])
+                        
+                    
+                    if requested_end_time_index > closest_teaching_range[0]:
+                        set_instructor_availability_dict(requested_start_time_index, closest_teaching_range[0])
+                    
+        return inst_avail_dict
+
+    instructor_availability_map = set_instructor_availability_map(
+        instructor_teaching_schedule_dict, instructor_availabilities_dict, duration
+    )
+
+    # convert datetime.timedelta to date.time - military time 
+    for day in instructor_availability_map:
+        for i, hour in enumerate(instructor_availability_map[day]):
+            if hour == True:
+                instructor_availability_map[day][i] = index_to_time(i, day, business_id)
+    # remove False from list 
+    for day in instructor_availability_map:
+        instructor_availability_map[day] = list(
+            filter(lambda a: a != False, instructor_availability_map[day])
+        )
+    
+    return instructor_availability_map
+
+

--- a/scheduler/utilities.py
+++ b/scheduler/utilities.py
@@ -6,6 +6,10 @@ from account.models import (
     InstructorOutOfOffice,
 )
 from onboarding.models import Business
+from scheduler.models import Session
+from django.utils.timezone import make_aware
+from django.utils import timezone
+from course.models import Course
 
 
 def time_to_index(time: datetime, day_of_week: str, business_id: int) -> int:
@@ -27,27 +31,81 @@ def index_to_time(index: int, day_of_week: str, business_id: int) -> datetime:
     today = datetime.today()
     business_start_time = (datetime.combine(today, start_time)).time()
     minutes = business_start_time.hour * 60 + business_start_time.minute
-
     total_minutes = minutes + (30 * index)
     final_time = timedelta(minutes=total_minutes)
     return final_time
 
 
+def duration_to_boolean_list(start_time, end_time):
+    today = datetime.today()
+    start_time = datetime.combine(today, start_time)
+    end_time = datetime.combine(today, end_time)
+    difference = end_time - start_time
+    total_minutes = difference.total_seconds() / 60
+    index = total_minutes / 30
+    return [True] * int(index)
+
+
 def get_buessiness_hours_map(buesiness_id: int) -> dict:
-    # create a function that returns a dict of days as keys and array of bools for the amount of hours in a day
+    availability_dict = {}
     business = Business.objects.get(id=buesiness_id)
-    avail = business.availability_list
-    r = avail
-    print(r)
+    avail = business.availability_list.all()
+
+    for e in avail:
+        if e.day_of_week not in availability_dict:
+            availability_dict[e.day_of_week] = duration_to_boolean_list(
+                e.start_time, e.end_time
+            )
+
+    return availability_dict
 
 
-def set_instructor_availabilities(
-    instructor_id: int, instructor_availiablities_map: dict
-) -> dict:
+def get_instructor_sessions(instructor_id: int, start_date, end_date) -> list:
+    weekdays = {
+        0: "monday",
+        1: "tuesday",
+        2: "wednesday",
+        3: "thursday",
+        4: "friday",
+        5: "saturday",
+        6: "sunday",
+    }
+    instructor_availabilities_dict = {}
+    instructor_sessions = Session.objects.filter(
+        start_datetime__range=(start_date, end_date),
+        end_datetime__range=(start_date, end_date),
+        instructor_id=instructor_id,
+    )
+
+    # Need to get start & end time of course
+    instructor_availability = InstructorAvailability.instructor
+    print(instructor_availability.instructor)
+
+    for e in instructor_sessions:
+        if weekdays[e.start_datetime.weekday()] not in instructor_availabilities_dict:
+            instructor_availabilities_dict[weekdays[e.start_datetime.weekday()]] = 1
+
+    print(instructor_availabilities_dict)
+
+
+def set_instructor_business_availabilities(instructor_id: int) -> dict:
     pass
 
 
-print(get_buessiness_hours_map(buesiness_id=1))
-# day = time(10, 30)
-# print(index_to_time(9, "monday", 1))
-# print(time_to_index(day, "monday", 1))
+def get_instructor_availabilities(instructor_id: int, start_date, end_date) -> dict:
+    # given an instructor ID and a start & end time
+    # return an object with possible availabilities
+    # get business hours map
+    #
+    pass
+
+
+st = time(10, 0)
+et = time(11, 00)
+sd = datetime(2020, 1, 26, 10, 0, tzinfo=timezone.utc)
+ed = datetime(2021, 10, 15, 11, 0, tzinfo=timezone.utc)
+# print(get_instructor_availabilities(2, sd, ed))
+print(get_instructor_sessions(5, sd, ed))
+# print(get_buessiness_hours_map(buesiness_id=1))
+# print(index_to_time(1, "monday", 1))
+# print(time_to_index(selected_time, "monday", 1))

--- a/scheduler/utilities.py
+++ b/scheduler/utilities.py
@@ -1,5 +1,4 @@
 from datetime import datetime, time, timedelta, date
-from typing import final
 from account.models import (
     Instructor,
     InstructorAvailability,
@@ -7,9 +6,10 @@ from account.models import (
 )
 from onboarding.models import Business
 from scheduler.models import Session
-from django.utils.timezone import make_aware
 from django.utils import timezone
 from course.models import Course
+
+print("something")
 
 
 def time_to_index(time: datetime, day_of_week: str, business_id: int) -> int:
@@ -78,14 +78,13 @@ def get_instructor_sessions(instructor_id: int, start_date, end_date) -> list:
     )
 
     # Need to get start & end time of course
-    instructor_availability = InstructorAvailability.instructor
-    print(instructor_availability.instructor)
+    instructor_availability = InstructorAvailability.objects.filter(instructor=2)
+
+    print(instructor_availability)
 
     for e in instructor_sessions:
         if weekdays[e.start_datetime.weekday()] not in instructor_availabilities_dict:
             instructor_availabilities_dict[weekdays[e.start_datetime.weekday()]] = 1
-
-    print(instructor_availabilities_dict)
 
 
 def set_instructor_business_availabilities(instructor_id: int) -> dict:
@@ -105,7 +104,7 @@ et = time(11, 00)
 sd = datetime(2020, 1, 26, 10, 0, tzinfo=timezone.utc)
 ed = datetime(2021, 10, 15, 11, 0, tzinfo=timezone.utc)
 # print(get_instructor_availabilities(2, sd, ed))
-print(get_instructor_sessions(5, sd, ed))
-# print(get_buessiness_hours_map(buesiness_id=1))
+# print(get_instructor_sessions(5, sd, ed))
+print(get_buessiness_hours_map(buesiness_id=1))
 # print(index_to_time(1, "monday", 1))
 # print(time_to_index(selected_time, "monday", 1))


### PR DESCRIPTION
## Utility Functions

### time_to_index( time, day_of_week, business_id) -> int:
* This function uses the start time of the business and the selected time to convert the time to index. 

### index_to_time(index, day_of_week, business_id) -> time:
* Function to convert indices to time depending on the start time of the business 

### duration_to_boolean_list(start_time, end_time) -> list:
* Creates a list of False values between a start and end time, this this will be used to create instructors availabilities

### get_business_hours_map(business_id) -> dict:
* Creates business hours map with day of week as key and value is a list of booleans 

### get_instructor_availabilities(instructor_id, business_id) -> dict:
* Compares the instructors availabilities with the business hours map and sets the available working time for selected instructor 

### find_instructor_teaching_schedule(day_of_week, instructor_sessions, business_id, weekdays) -> list(tuple) | list([])
* Finds all unique unavailable start times for certain day of week. Given a list of instructor availabilities boolean list, this will return the start times in a list of tuples or if they are not available, an empty list 

### set_instructor_availability_map(instructor_teaching_schedule, inst_avail_dict, duration) -> dict:
* This function does the logic of taking the instructor teaching schedule and their availability and finds any duration conflict. Returns the instructors availabilities dict. 

### get_instructor_tutoring_availability(instructor_id, business_id, start_date, end_date, duration) -> list(dict):
* final function to be called in the schema
* weekdays map to help find the correct days in human readable terms 
* Uses get_instructor_availabilities, find_instructor_teaching_schedule, set_instructor_availability_map, & index_to_time to help find instructors availabilities. 